### PR TITLE
FT - app does not crash anymore when a translation does not exists

### DIFF
--- a/templates/I18n/index.js
+++ b/templates/I18n/index.js
@@ -1,0 +1,20 @@
+import I18n from 'react-native-i18n'
+
+// This function is a wrapper to avoid exception wich leads in a crash
+const translateOrFallback = msg => {
+  let localMsg = I18n.t('unknownError')
+  try{
+    localMsg = I18n.t(msg)
+  }catch(e){
+    if(__DEV__){
+      console.log(`translation "${msg}" does not exists in translations files`)
+    }
+  }
+
+  return localMsg
+}
+
+export default {
+  ...I18n,
+  t: translateOrFallback
+}


### PR DESCRIPTION
A new feature to avoiding a crash when we request a translation that does not exists.
It still have all the features of I18n in the exported object, we just overwriting the I18n.t function