### PR TITLE
DOC - edit readme to import index.js instead of RN module

### DIFF
--- a/templates/I18n/README.md
+++ b/templates/I18n/README.md
@@ -14,7 +14,7 @@ Run `ignite add i18n`.
 
 TODO: Real usage example.
 
-    import I18n from 'react-native-i18n';
+    import I18n from 'App/I18n';
 
     render() {
     ...


### PR DESCRIPTION
Propose to import the ignite module with crash prevention instead of react-native-i18n module

PS: Sorry, I've not been able to put this file change in my PR with Github GUI.
