### PR TITLE
FIX - app could crash if default translation not exists

### DIFF
--- a/templates/I18n/index.js
+++ b/templates/I18n/index.js
@@ -2,7 +2,7 @@ import I18n from 'react-native-i18n'
 
 // This function is a wrapper to avoid exception wich leads in a crash
 const translateOrFallback = msg => {
-  let localMsg = I18n.t('unknownError')
+  let localMsg = msg
   try{
     localMsg = I18n.t(msg)
   }catch(e){


### PR DESCRIPTION
Stupid error in https://github.com/infinitered/ignite-i18n/pull/9

We tried to find a unknownError by default but this one is an extra translation I've personally add. Plus you don't necessary try to send an error to the client. The best thing to do is to send the message you try to translate directly to the client if no translation exists.