### PR TITLE
FIX - return original message if translation does not exists

### DIFF
--- a/templates/I18n/index.js
+++ b/templates/I18n/index.js
@@ -1,16 +1,27 @@
 import I18n from 'react-native-i18n'
 
-// This function is a wrapper to avoid exception wich leads in a crash
-const translateOrFallback = msg => {
-  let localMsg = msg
-  try{
-    localMsg = I18n.t(msg)
-  }catch(e){
-    if(__DEV__){
-      console.log(`translation "${msg}" does not exists in translations files`)
-    }
-  }
+const missingTranslationRegex = /^\[missing ".*" translation\]$/
 
+// This function is a wrapper to avoid exception wich leads in a crash
+const translateOrFallback = initialMsg => {  
+  // We tried to translate something else than a string
+  // The native I18n function will simply crash instead of rejecting the attempt with an error message
+  if(typeof initialMsg !== 'string'){
+    __DEV__ && console.log(`I18n: you must give a string to translate instead of "${typeof initialMsg}"`)
+        
+    return '' // We don't return any message as we don't know what to send
+  }
+  
+  let localMsg = I18n.t(initialMsg)
+
+  // The translation does not exist, the default message is not very sexy
+  // Instead we return the message we tried to translate
+  if(missingTranslationRegex.test(localMsg)) {
+    __DEV__ && console.log(`translation "${initialMsg}" does not exists in translations files`)
+  
+    return initialMsg
+  }
+  
   return localMsg
 }
 


### PR DESCRIPTION
We was returning an unsexy error message instead of the original message.
Better error message if the message to translate is not a string, now we return an empty message instead of returning the object passed in parameters