### PR TITLE
FIX - do not drop options

### DIFF
--- a/templates/I18n/index.js
+++ b/templates/I18n/index.js
@@ -3,7 +3,7 @@ import I18n from 'react-native-i18n'
 const missingTranslationRegex = /^\[missing ".*" translation\]$/
 
 // This function is a wrapper to avoid exception wich leads in a crash
-const translateOrFallback = initialMsg => {
+const translateOrFallback = (initialMsg, options) => {
   // We tried to translate something else than a string
   // The native I18n function will simply crash instead of rejecting the attempt with an error message
   if (typeof initialMsg !== 'string') {
@@ -12,7 +12,7 @@ const translateOrFallback = initialMsg => {
     return '' // We don't return any message as we don't know what to send
   }
 
-  let localMsg = I18n.t(initialMsg)
+  let localMsg = I18n.t(initialMsg, options)
 
   // The translation does not exist, the default message is not very sexy
   // Instead we return the message we tried to translate


### PR DESCRIPTION
Passing options like `I18n.t('foo', { value: 'bar' })` does not work because only the string is passed by `translateOrFallback`. This should fix it. 